### PR TITLE
Load balancing with both HTTP and TCP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     build: ./load-balancer/
     ports:
       - 8080:80
+      - 8081:81
       - 9000:9000
     volumes:
       # bind haproxy.cfg to the container

--- a/load-balancer/haproxy.cfg
+++ b/load-balancer/haproxy.cfg
@@ -10,19 +10,39 @@
 #---------------------------------------------------------------------
 # common defaults that all the 'listen' and 'backend' sections will
 # use if not designated in their block
+global 
+  daemon
+  log stdout format raw local0
 #---------------------------------------------------------------------
 defaults
-  mode http
-  timeout client 10s
-  timeout connect 5s
-  timeout server 10s
-  timeout http-request 10s
+  timeout client 1200s
+  timeout connect 605s
+  timeout server 1000s
+  timeout http-request 1000s
+  log global
+  option tcplog
 
 #---------------------------------------------------------------------
-# main frontend which proxys to the backends
+# stats frontend
 #---------------------------------------------------------------------
-frontend main
+
+frontend stats
+  bind :9000
+  mode http
+  stats enable
+  stats refresh 5s
+  stats hide-version
+  stats uri /
+  stats realm Haproxy\ Statistics
+  stats auth Username:Password
+
+#---------------------------------------------------------------------
+# http frontend
+#---------------------------------------------------------------------
+frontend http-front
   bind 0.0.0.0:80
+
+  mode http
 
   # Rate limit based on parameter '?ip=....' in URL
   stick-table type string size 100k  expire 30s  store http_req_rate(20s)   # Window of 10 seconds
@@ -35,21 +55,36 @@ frontend main
 #   stick-table  type ipv6  size 100k  expire 30s  store http_req_rate(10s)
 #   http-request track-sc0 src
 #   http-request deny deny_status 429 if { sc_http_req_rate(0) gt 20 }
-  default_backend app
 
-  listen stats
-    bind :9000
-    mode http
-    stats enable
-    stats hide-version
-    stats realm Haproxy\ Statistics
-    stats uri /
-    stats auth Username:Password
+  default_backend http-app
+
 
 #---------------------------------------------------------------------
-# round robin balancing between the various backends
+# tcp frontend
 #---------------------------------------------------------------------
-backend app
+frontend tcp-front
+  bind 0.0.0.0:81
+
+  mode tcp
+
+#   # Rate Limit base on ip address of client
+#   stick-table  type ipv6  size 100k  expire 30s  store http_req_rate(10s)
+#   http-request track-sc0 src
+#   http-request deny deny_status 429 if { sc_http_req_rate(0) gt 20 }
+
+  default_backend tcp-app
+
+#---------------------------------------------------------------------
+# round robin balancing between the servers
+#---------------------------------------------------------------------
+backend http-app
+  mode http
+  balance roundrobin
+  server  app1 node-1:80 check
+  server  app2 node-2:80 check
+
+backend tcp-app
+  mode tcp
   balance roundrobin
   server  app1 node-1:80 check
   server  app2 node-2:80 check


### PR DESCRIPTION
Changed HAProxy config to enable load balancing with both HTTP and TCP modes. HTTP load balancing is on port 8080 and TCP on port 8081. This required creating two haproxy frontends and backends, which connect to the same servers.